### PR TITLE
fix header link error: change to absolute path

### DIFF
--- a/_layouts/layout.html
+++ b/_layouts/layout.html
@@ -17,9 +17,9 @@
     
     <nav>
       <ul>
-        <li><a href="./index.html">HOME</a></li>
-        <li><a href="./about.html">ABOUT</a></li>
-        <li><a href="./news.html">NEWS</a></li>
+        <li><a href="/index.html">HOME</a></li>
+        <li><a href="/about.html">ABOUT</a></li>
+        <li><a href="/news.html">NEWS</a></li>
       </ul>
     </nav>
 


### PR DESCRIPTION
header link was relative path, so it can't reach from posts.

ヘッダーリンクが相対パスになってて_postsの記事ページから飛べなかったのでルートからのパスに修正しました。
