### PR TITLE
Fix description of masutaka dot.emacs

### DIFF
--- a/_posts/core-samples/2014-09-03-dot-emacs-list.md
+++ b/_posts/core-samples/2014-09-03-dot-emacs-list.md
@@ -116,7 +116,7 @@ tags: [init.el, dot-emacs]
 
 [masutaka/.emacs ? Gists](https://gist.github.com/masutaka/8177244)
 
-- auto-install + package.el 
+- package.el 
 - 単一ファイルで見やすい
 
 [.emacs.d/init.el at master ? yoshitia/.emacs.d ? GitHub](https://github.com/yoshitia/.emacs.d/blob/master/init.el)


### PR DESCRIPTION
まとめありがとうございました。
auto-install.elは今は使ってないので修正しました。
