### PR TITLE
change contents order

### DIFF
--- a/index.md
+++ b/index.md
@@ -7,6 +7,25 @@ title: 日本のEmacsユーザーのためのハブサイト
 **{{ site.title }}**はEmacsと日本語に関わるあらゆるリソースを集約することを目的としたコミュニティサイトです。  
 Emacsと{{ site.title }}についての詳細は[このサイトについて](/about.html)をごらんください。
 
+## コンテンツ
+
+* [**{{ site.title }}**で管理しているパッケージ](/maintenances/)
+* [Emacsのバージョン](/tips/versions.html)
+* [おすすめパッケージ紹介](/packages/)
+* [Emacsビギナーのためのページ](/beginner.html)
+* helm とは
+* いろいろな日本語入力環境
+* [Linuxでのbuild方法](/build-linux.html)
+* [EmacsとVimの機能対応表](https://docs.google.com/spreadsheets/d/184i0Cmnfd0CdmPw2AVMMvmmnl7Gz5ryPqTaxnpIyqRE/edit?usp=sharing)
+
+## お知らせ
+
+<ul class="posts">
+  {% for post in site.posts %}
+    <li><span>{{ post.date | date: "%Y-%m-%d" }}</span> &raquo; <a href="{{ BASE_PATH }}{{ post.url }}">{{ post.title }}</a></li>
+  {% endfor %}
+</ul>
+
 ## Slack <small>- [emacs-jp.slack.com](https://emacs-jp.slack.com/)</small>
 
 Emacs JPのSlack teamには多くのEmacsユーザーが常駐しています。  
@@ -23,22 +42,3 @@ Emacsについて、
 * こんなカラーテーマが欲しい
 
 ……など、Slackで質問すれば解決できるかもしれません。
-
-## お知らせ
-
-<ul class="posts">
-  {% for post in site.posts %}
-    <li><span>{{ post.date | date: "%Y-%m-%d" }}</span> &raquo; <a href="{{ BASE_PATH }}{{ post.url }}">{{ post.title }}</a></li>
-  {% endfor %}
-</ul>
-
-## コンテンツ
-
-* [**{{ site.title }}**で管理しているパッケージ](/maintenances/)
-* [Emacsのバージョン](/tips/versions.html)
-* [おすすめパッケージ紹介](/packages/)
-* [Emacsビギナーのためのページ](/beginner.html)
-* helm とは
-* いろいろな日本語入力環境
-* [Linuxでのbuild方法](/build-linux.html)
-* [EmacsとVimの機能対応表](https://docs.google.com/spreadsheets/d/184i0Cmnfd0CdmPw2AVMMvmmnl7Gz5ryPqTaxnpIyqRE/edit?usp=sharing)


### PR DESCRIPTION
@zonuexe
EmacsJPを訪れた方はSlackのリンクを発見したいのではなく、何かコン
テンツを求めていると思います。

現在、コンテンツがあまり準備できていないということは分かりますが、
これからコンテンツを中心としたサイトにするために、「コンテンツ」
を一番上に配置しました。

トップページの大きな変更なので意見を伺えればと思います。
よろしくお願いします。