### PR TITLE
add docker-compose environment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,12 @@
+## test.yml
+
+name: Main workflow
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build site
+      run: 'make build'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+## Dockerfile
+
+FROM ubuntu:bionic
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt update && apt -y upgrade
+
+# In Gemfile:
+#   github-pages was resolved to 206, which depends on
+#     jekyll-commonmark-ghpages was resolved to 0.1.6, which depends on
+#       jekyll-commonmark was resolved to 1.3.1, which depends on
+#         commonmarker
+
+# In Gemfile:
+#   github-pages was resolved to 206, which depends on
+#     jekyll-mentions was resolved to 1.5.1, which depends on
+#       html-pipeline was resolved to 2.13.0, which depends on
+#         nokogiri
+
+# commonmarker requires make
+# nokogiri requires zlib
+RUN apt install -y build-essential ruby ruby-dev zlib1g-dev
+RUN gem update --system
+RUN gem install bundler
+
+COPY Gemfile /
+
+RUN bundle install

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+## Makefile
+
+all:
+
+DOCKERLOCK := .docker.lock
+
+##############################
+
+.PHONY: all
+all: up
+
+$(DOCKERLOCK): up
+	touch $@
+
+.PHONY: up
+up:
+	docker-compose up -d
+
+# -T option https://github.com/docker/compose/issues/7306
+.PHONY: build
+build: $(DOCKERLOCK)
+	docker-compose exec -T main jekyll build --trace
+
+.PHONY: down
+down:
+	docker-compose down
+	rm -rf $(DOCKERLOCK)

--- a/Rakefile
+++ b/Rakefile
@@ -100,8 +100,13 @@ end # task :page
 
 desc "Launch preview environment"
 task :preview do
-  system "jekyll serve -w"
+  sh "jekyll serve -w"
 end # task :preview
+
+desc "Build static web page via jekyll"
+task :build do
+  sh "jekyll build --trace"
+end
 
 # Public: Alias - Maintains backwards compatability for theme switching.
 task :switch_theme => "theme:switch"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+## docker-compose.yml
+
+version: '3'
+
+services:
+  main:
+    build: .
+    volumes:
+      - .:/work
+    ports:
+      - 4000:4000
+    working_dir: /work
+    command: jekyll serve --host 0.0.0.0


### PR DESCRIPTION
Dockerfile及びdocker-composeを追加しました。

@zonuexe
お時間があるときに見て頂きたいのですが、このPRについて、下記のことに困っています。

1. containerへlocalhost:4000で通信できない問題
   「docker-comose up」で起動すると以下のログが表示されます。

   ```
   $ docker-compose up
   Creating network "emacs-jpgithubcom_default" with the default driver
   Creating emacs-jpgithubcom_main_1 ... done
   Attaching to emacs-jpgithubcom_main_1
   main_1  | /usr/lib/ruby/vendor_ruby/rubygems/defaults/operating_system.rb:10: warning: constant Gem::ConfigMap is deprecated
   main_1  | jekyll serve -w
   main_1  | Configuration file: /work/_config.yml
   main_1  |             Source: /work
   main_1  |        Destination: /work/_site
   main_1  |  Incremental build: disabled. Enable with --incremental
   main_1  |       Generating... 
   main_1  |        Jekyll Feed: Generating feed for posts
   main_1  |                     done in 0.862 seconds.
   main_1  |  Auto-regeneration: enabled for '/work'
   main_1  |     Server address: http://127.0.0.1:4000
   main_1  |   Server running... press ctrl-c to stop.
   ```

   しかし、ホストPCからlocalhost:4000にアクセスしても表示されません。
   curlの表示は以下の通りです。

   ```
   $ curl localhost:4000
   curl: (56) Recv failure: Connection reset by peer
   ```

   メッセージで検索すると[qiita](https://qiita.com/amuyikam/items/01a8c16e3ddbcc734a46)の投稿が見つかり、以下でjekyllを起動することでホストPCから疎通できました。
   
   ```diff
   1 file changed, 1 insertion(+), 1 deletion(-)
   docker-compose.yml | 2 +-
   
   modified   docker-compose.yml
   @@ -10,4 +10,4 @@ services:
        ports:
          - 4000:4000
        working_dir: /work
   -    command: rake preview
   +    command: jekyll serve --host 0.0.0.0
   ```
   
   しかし、docker-composerで「ポートフォワードの設定を -p localhost:8000:8000 などに変更して外部からのアクセスを遮断する」の設定方法が分からず、詰まっています。。
   また、jekyllに0.0.0.0で公開させる以外の解決方法もあるかもしれないと思っています。
   
2. GitHub ActionsのCIの問題
   docker-composeを追加したことによりローカルの環境を簡単に統一できるようになりました。
   これはGitHub Actionsでもテストしやすくなるということで、書いてみたのですが、逐一docker buildが走り、1回あたり[5分近くかかります](https://github.com/conao3/emacs-jp.github.com/actions/runs/229974781)。
   これは仕方ないという面もありますが、もっと高速化できないかなと思っています。
   具体的には、あらかじめ作っておいたimageをpullして使うようにすれば早くなるかもしれないと思っていますが、手元のDockerfileとDockerHubにpushしたimageの不整合が将来的に起こらないかなと心配になっています。
   (Dockerfileとdocker-compose.ymlがレポジトリルートにある一方で、Dockerfileを書き換えてもそれが直接docker-compose環境に反映されないのは直感的でないと思います)

上記2点について、アドバイスを頂ければと思います。。