### PR TITLE
Add 更新情報 in front page

### DIFF
--- a/docs/_posts/2013-02-12-start-emacs-jp.md
+++ b/docs/_posts/2013-02-12-start-emacs-jp.md
@@ -3,6 +3,8 @@ layout: post
 author: kozo2
 title: Emacs JPはじめます
 tags: [announcement]
+date: 2013-02-12
+last_modified: 2013-02-12
 ---
 {% include JB/setup %}
 

--- a/docs/_posts/2014-09-03-dot-emacs-list.md
+++ b/docs/_posts/2014-09-03-dot-emacs-list.md
@@ -2,6 +2,8 @@
 layout: post
 title: issue#15に投稿されたinit.elのリストをまとめました
 tags: [init.el, dot-emacs]
+date: 2014-09-03
+last_modified: 2014-09-03
 ---
 {% include JB/setup %}
 

--- a/docs/_posts/2019-01-01-reboot-emacs-jp.md
+++ b/docs/_posts/2019-01-01-reboot-emacs-jp.md
@@ -3,6 +3,8 @@ layout: post
 author: zonuexe
 title: 2019年Emacs JPを再始動します
 tags: [announcement]
+date: 2019-01-01
+last_modified: 2019-01-01
 ---
 {% include JB/setup %}
 

--- a/docs/_posts/2019-03-03-tokyo-emacs-01.md
+++ b/docs/_posts/2019-03-03-tokyo-emacs-01.md
@@ -3,6 +3,8 @@ layout: post
 author: zonuexe
 title: 東京Emacsひなまつり(勉強会)を開催しました
 tags: [announcement]
+date: 2019-03-03
+last_modified: 2019-03-03
 ---
 {% include JB/setup %}
 

--- a/docs/_posts/2019-05-08-tokyo-emacs-02.md
+++ b/docs/_posts/2019-05-08-tokyo-emacs-02.md
@@ -3,6 +3,8 @@ layout: post
 author: zonuexe
 title: 東京Emacs勉強会 端午の節句を開催しました
 tags: [announcement]
+date: 2019-05-08
+last_modified: 2019-05-08
 ---
 {% include JB/setup %}
 

--- a/docs/_posts/2019-07-24-tokyo-emacs-03.md
+++ b/docs/_posts/2019-07-24-tokyo-emacs-03.md
@@ -3,6 +3,8 @@ layout: post
 author: zonuexe
 title: 東京Emacs勉強会 七夕まつりを開催しました
 tags: [announcement]
+date: 2019-07-24
+last_modified: 2019-07-24
 ---
 {% include JB/setup %}
 

--- a/docs/env/go.md
+++ b/docs/env/go.md
@@ -5,6 +5,8 @@ title: "Goプログラミングのための環境構築"
 description: "Goプログラミングのための環境構築"
 category: "env"
 tags: ["env", "go", "golang"]
+date: 2013-09-26
+last_modified: 2020-07-01
 ---
 {% include JB/setup %}
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,20 @@ Emacsと{{ site.title }}についての詳細は[このサイトについて](/a
   {% endfor %}
 </ul>
 
+## 更新情報
+
+{% assign target
+     = site.pages | concat: site.posts
+       | where_exp: 'item', 'item.last_modified'
+       | sort: "last_modified"
+       | reverse %}
+
+{%- for post in target limit:10 %}
+* {{ post.last_modified | date: "%Y-%m-%d" }} &raquo; <small>{{ post.dir | slice: 1,100 -}}</small>[{{ post.title }}]({{ post.url }})
+{%- endfor -%}
+
+{% assign target = nil %}
+
 ## Slack <small>- [emacs-jp.slack.com](https://emacs-jp.slack.com/)</small>
 
 Emacs JPのSlack teamには多くのEmacsユーザーが常駐しています。  

--- a/docs/packages/ac-ispell.md
+++ b/docs/packages/ac-ispell.md
@@ -5,6 +5,8 @@ title: "ac-ispell.el"
 description: "ispellの auto-complete source"
 category: "auto-complete"
 tags: ["auto-complete"]
+date: 2014-04-15
+last_modified: 2014-04-15
 ---
 {% include JB/setup %}
 

--- a/docs/packages/anzu.md
+++ b/docs/packages/anzu.md
@@ -5,6 +5,8 @@ title: "anzu"
 description: "検索情報をモードラインに表示"
 category: "mode-line"
 tags: ["mode-line", "search"]
+date: 2013-10-14
+last_modified: 2013-10-27
 ---
 {% include JB/setup %}
 

--- a/docs/packages/elisp-slime-nav.md
+++ b/docs/packages/elisp-slime-nav.md
@@ -5,6 +5,8 @@ title: "elisp-slime-nav"
 description: "Slime-style navigation for Emacs Lisp"
 category: "elisp"
 tags: ["programming", "elisp"]
+date: 2013-05-06
+last_modified: 2014-09-09
 ---
 {% include JB/setup %}
 

--- a/docs/packages/evil.md
+++ b/docs/packages/evil.md
@@ -5,6 +5,8 @@ title: "evil"
 description: "Vimのエミュレート"
 category: "evil"
 tags: ["evil"]
+date: 2014-09-09
+last_modified: 2020-05-28
 ---
 {% include JB/setup %}
 

--- a/docs/packages/git-gutter.md
+++ b/docs/packages/git-gutter.md
@@ -5,6 +5,8 @@ title: "git-gutter.el"
 description: "GitGutterの Emacs版"
 category: "vcs"
 tags: ["vcs"]
+date: 2013-03-17
+last_modified: 2020-06-05
 ---
 {% include JB/setup %}
 

--- a/docs/packages/helm-ag.md
+++ b/docs/packages/helm-ag.md
@@ -5,6 +5,8 @@ title: "helm-ag"
 description: "The Silver Seacherの helmインタフェース"
 category: "helm"
 tags: ["helm"]
+date: 2013-03-22
+last_modified: 2013-05-10
 ---
 {% include JB/setup %}
 

--- a/docs/packages/helm-descbinds.md
+++ b/docs/packages/helm-descbinds.md
@@ -5,6 +5,8 @@ title: "helm-descbinds"
 description: "describe-bindingsの helmインタフェース"
 category: "helm"
 tags: ["helm"]
+date: 2013-05-06
+last_modified: 2013-05-09
 ---
 {% include JB/setup %}
 

--- a/docs/packages/helm-gtags.md
+++ b/docs/packages/helm-gtags.md
@@ -5,6 +5,8 @@ title: "helm-gtags"
 description: "GNU Globalの helmインタフェース"
 category: "helm"
 tags: ["helm", "tagjump"]
+date: 2013-03-19
+last_modified: 2013-05-10
 ---
 {% include JB/setup %}
 

--- a/docs/packages/helm-open-github.md
+++ b/docs/packages/helm-open-github.md
@@ -5,6 +5,8 @@ title: "helm-open-github"
 description: "Githubユーティリティ"
 category: "helm"
 tags: ["helm", "github"]
+date: 2014-03-02
+last_modified: 2016-09-04
 ---
 {% include JB/setup %}
 

--- a/docs/packages/package.md
+++ b/docs/packages/package.md
@@ -5,6 +5,8 @@ title: package
 description: "パッケージ管理ツール"
 category: "package"
 tags: ["package"]
+date: 2013-09-25
+last_modified: 2020-06-05
 ---
 {% include JB/setup %}
 

--- a/docs/packages/rainbow-mode.md
+++ b/docs/packages/rainbow-mode.md
@@ -4,6 +4,8 @@ title: "rainbow-mode"
 description: "色名, カラーコードの視覚化"
 category: "face"
 tags: ["face"]
+date: 2013-05-06
+last_modified: 2013-05-06
 ---
 {% include JB/setup %}
 

--- a/docs/tips/emacs-in-2020.md
+++ b/docs/tips/emacs-in-2020.md
@@ -2,6 +2,8 @@
 layout: page
 author: conao3
 title: "2020年代のEmacs入門"
+date: 2020-08-25
+last_modified: 2020-08-29
 ---
 {% include JB/setup %}
 

--- a/docs/tips/emacs-jp-maintenance.md
+++ b/docs/tips/emacs-jp-maintenance.md
@@ -4,6 +4,8 @@ author: eiel
 title: "Emacs JP で管理しているパッケージ"
 description: "Emacs JP で管理しているパッケージ"
 tags: ["tips"]
+date: 2013-03-10
+last_modified: 2013-03-18
 ---
 {% include JB/setup %}
 

--- a/docs/tips/environment-variable.md
+++ b/docs/tips/environment-variable.md
@@ -5,6 +5,8 @@ title: "環境変数の設定"
 description: "環境変数の設定"
 category: "shell"
 tags: ["shell"]
+date: 2013-10-13
+last_modified: 2013-10-13
 ---
 {% include JB/setup %}
 

--- a/docs/tips/install-emacs.md
+++ b/docs/tips/install-emacs.md
@@ -2,6 +2,8 @@
 layout: page
 author: conao3
 title: "Emacsのインストール"
+date: 2020-08-25
+last_modified: 2020-08-27
 ---
 {% include JB/setup %}
 

--- a/docs/tips/package-format.md
+++ b/docs/tips/package-format.md
@@ -5,6 +5,8 @@ title: "パッケージフォーマット"
 description: "Package Format"
 category: "package"
 tags: ["package", "tips"]
+date: 2013-10-11
+last_modified: 2013-10-12
 ---
 {% include JB/setup %}
 

--- a/docs/tips/package-management.md
+++ b/docs/tips/package-management.md
@@ -3,6 +3,8 @@ layout: page
 author: sabottenda
 title: "パッケージの管理方法"
 description: "Package Management"
+date: 2013-04-01
+last_modified: 2014-05-14
 ---
 {% include JB/setup %}
 

--- a/docs/tips/tutorial-ja.md
+++ b/docs/tips/tutorial-ja.md
@@ -2,6 +2,8 @@
 layout: page
 author: conao3
 title: "Emacsチュートリアル 日本語訳"
+date: 2020-08-25
+last_modified: 2020-08-25
 ---
 {% include JB/setup %}
 

--- a/docs/tips/versions.md
+++ b/docs/tips/versions.md
@@ -3,6 +3,8 @@ layout: page
 author: zonuexe
 title: "Emacsのバージョン"
 description: "今日にEmacsと呼ばれるGNU Emacsのバージョン表記とリリースの種類、過去の更新履歴についてまとめます。"
+date: 2019-01-13
+last_modified: 2020-09-02
 ---
 {% include JB/setup %}
 


### PR DESCRIPTION
記事について、gitのログから追加日と変更日を追加して
「更新情報」をフロントページに表示するようにしました。