### PR TITLE
add github link to each article source

### DIFF
--- a/docs/_includes/themes/twitter/page.html
+++ b/docs/_includes/themes/twitter/page.html
@@ -23,12 +23,18 @@
         </div>
         <div>
           <span class="author">Author: {{ author }}</span><br>
-          {% if page.date != empty %}
+          {% if page.date != nil %}
           <span class="date">Published: {{ page.date | date: "%Y-%m-%d" }}</span><br>
           {% endif %}
-          {% if page.last_modified != empty %}
+          {% if page.last_modified != nil %}
           <span class="lastmoddate">Last Modified: {{ page.last_modified | date: "%Y-%m-%d" }}</span><br>
           {% endif %}
+          <span class="githubsource">GitHub Source:
+            <a href="https://github.com/emacs-jp/emacs-jp.github.com/blob/master/docs/{{ page.path }}">md</a>
+            {%- if page.org != nil -%}
+            , <a href="https://github.com/emacs-jp/emacs-jp.github.com/blob/master/docs/org{{ page.url }}.org">org</a>
+            {% endif %}
+          </span>
         </div>
       </div>
     </div>

--- a/docs/_sass/_style.scss
+++ b/docs/_sass/_style.scss
@@ -129,6 +129,10 @@ img {
     color: lighten($foreground, 30%);
 }
 
+.authordiv .githubsource {
+    color: lighten($foreground, 30%);
+}
+
 ins {
     display: inline-block;
     padding: 0.8rem;

--- a/docs/org/packages/cort.org
+++ b/docs/org/packages/cort.org
@@ -8,6 +8,7 @@
 #+link: files file+sys:../files/
 
 #+gfm_tags: test cort conao3
+#+gfm_custom_front_matter: :org t
 
 * 概要
 [[https://github.com/conao3/cort.el/][cort]]は[[https://github.com/conao3/][conao3]]によって作成された、シンプルなElispテストフレームワークです。

--- a/docs/org/packages/ddskk-posframe.org
+++ b/docs/org/packages/ddskk-posframe.org
@@ -8,6 +8,7 @@
 #+link: files file+sys:../files/
 
 #+gfm_tags: ddskk posframe ddskk-posframe conao3
+#+gfm_custom_front_matter: :org t
 
 * 概要
 [[https://github.com/conao3/ddskk-posframe.el/][ddskk-posframe]]は[[https://github.com/conao3/][conao3]]によって作成された、ddskkツールチップの[[https://github.com/tumashu/posframe][posframe]]フロントエンドです。

--- a/docs/org/tips/how-to-create-patch.org
+++ b/docs/org/tips/how-to-create-patch.org
@@ -8,6 +8,7 @@
 #+link: files file+sys:../files/
 
 #+gfm_tags: patch
+#+gfm_custom_front_matter: :org t
 
 * 概要
 筆者は最近初めてEmacsにパッチを送り、[[https://emba.gnu.org/emacs/emacs/-/commit/66509f2ead423b814378a44a55c9f63dcb1e149b][無事マージ]]されました。

--- a/docs/packages/cort.md
+++ b/docs/packages/cort.md
@@ -5,6 +5,7 @@ title: "cort: シンプルなテストフレームワーク"
 tags: [test, cort, conao3]
 date: 2020-09-04
 last_modified: 2020-09-04
+org: t
 ---
 {% include JB/setup %}
 

--- a/docs/packages/ddskk-posframe.md
+++ b/docs/packages/ddskk-posframe.md
@@ -5,6 +5,7 @@ title: "ddskk-posframe: ddskkツールチップposframeフロントエンド"
 tags: [ddskk, posframe, ddskk-posframe, conao3]
 date: 2020-09-04
 last_modified: 2020-09-04
+org: t
 ---
 {% include JB/setup %}
 

--- a/docs/tips/how-to-create-patch.md
+++ b/docs/tips/how-to-create-patch.md
@@ -5,6 +5,7 @@ title: "Emacsにパッチを送るには"
 tags: [patch]
 date: 2020-09-13
 last_modified: 2020-09-13
+org: t
 ---
 {% include JB/setup %}
 


### PR DESCRIPTION
それぞれの記事にGitHubのソースへのリンクを表示するようにしました。
これにより読者が記事の修正などをしやすくなると思います。
(editリンクにはしていません。editリンクは押すとその瞬間forkされ、
ユーザーの意図と動作が異なっていると感じるためです。)