### PR TITLE
sort dir > title in archive page

### DIFF
--- a/docs/archive.md
+++ b/docs/archive.md
@@ -18,7 +18,8 @@ maint: true
         | where_exp: 'item', 'item.redirect_to == nil'
         | where_exp: 'item', 'item.maint == nil'
         | where_exp: 'item', 'item.title != nil'
-        | sort: 'title' %}
+        | sort: 'title'
+        | sort: 'dir' %}
 
 {% for page in pages_list %}
 * <small>{{ page.dir | slice: 1,100 }}</small>[{{ page.title }}]({{ page.url }})


### PR DESCRIPTION
Archiveページにおいて、タイトルだけでなく、所属しているディレクト
リの名前を考慮するようにしました。