### PR TITLE
/docs/packages/index.mdの表現を一部修正

### DIFF
--- a/docs/packages/index.md
+++ b/docs/packages/index.md
@@ -4,7 +4,7 @@ title: Emacsパッケージ紹介
 ---
 {% include JB/setup %}
 
-Emacs24に標準搭載されている `package.el` を利用してインストール可能なパッケージの中からおすすめのパッケージを紹介します。
+Emacs24以降に標準搭載されている `package.el` を利用してインストール可能なパッケージの中からおすすめのパッケージを紹介します。
 
 {% assign pages_list
      = site.pages


### PR DESCRIPTION
「Emacs24に標準搭載されている」という表現だと、Emacs24のみだという勘違いされる可能性があるのではと思ったので、「Emacs24以降に標準搭載されている」に変えました。