### PR TITLE
use word-spacing hack instead of just padding

### DIFF
--- a/docs/_sass/_style.scss
+++ b/docs/_sass/_style.scss
@@ -79,8 +79,10 @@ td {
     padding-right: 2rem;
 }
 
-a, code, kbd {
-    padding: 0 0.3rem;
+a::before, a::after, code::before, code::after, kbd::before, kbd::after {
+    content: ' ';
+    font-size: 0;
+    word-spacing: 0.2rem;
 }
 
 pre code {


### PR DESCRIPTION
Add small padding on both sides of `a`, `code`, and `kbd`.
But do not add it at the beginning of the line.

---
Special thanks for [vim-jp](https://vim-jp.org/)#tech-javascript users!