### PR TITLE
update install commands for rust-analyzer to catch up recent changes

### DIFF
--- a/docs/env/rust.md
+++ b/docs/env/rust.md
@@ -72,13 +72,14 @@ rust-analyzerを `/PATH/TO/rust-analyzer` に保存するとして、以下の�
 # x86_64 Linux
 $ curl -sL https://github.com/rust-analyzer/rust-analyzer/releases/latest/download/rust-analyzer-x86_64-unknown-linux-gnu.gz | zcat > /PATH/TO/rust-analyzer
 
-# x86_64 macOS
-$ curl -sL https://github.com/rust-analyzer/rust-analyzer/releases/latest/download/rust-analyzer-x86_64-apple-darwin.gz | zcat > /PATH/TO/rust-analyzer
+# macOS
+$ brew install rust-analyzer
 
 # x86_64 Windows
 $ curl -sL https://github.com/rust-analyzer/rust-analyzer/releases/latest/download/rust-analyzer-x86_64-pc-windows-msvc.gz | zcat >  /PATH/TO/rust-analyzer.exe
 ```
 
+[rust-analyzerのマニュアル](https://rust-analyzer.github.io/manual.html#rust-analyzer-language-server-binary)も参考にして下さい。
 
 rust-analyzerは毎週更新されるので使う方はGitHubの右上にある[Watch]から[Custom]の[Releases]にチェックを入れて、毎週のリリースの通知を受け取るとよいでしょう[^1]
 

--- a/docs/env/rust.md
+++ b/docs/env/rust.md
@@ -69,14 +69,14 @@ rust-analyzerを `/PATH/TO/rust-analyzer` に保存するとして、以下の�
 
 
 ``` console
-# Linux
-$ curl -L https://github.com/rust-analyzer/rust-analyzer/releases/latest/download/rust-analyzer-linux -o /PATH/TO/rust-analyzer
+# x86_64 Linux
+$ curl -sL https://github.com/rust-analyzer/rust-analyzer/releases/latest/download/rust-analyzer-x86_64-unknown-linux-gnu.gz | zcat > /PATH/TO/rust-analyzer
 
-# macOS
-$ curl -L https://github.com/rust-analyzer/rust-analyzer/releases/latest/download/rust-analyzer-mac -o /PATH/TO/rust-analyzer
+# x86_64 macOS
+$ curl -sL https://github.com/rust-analyzer/rust-analyzer/releases/latest/download/rust-analyzer-x86_64-apple-darwin.gz | zcat > /PATH/TO/rust-analyzer
 
-# Windows
-$ curl -L https://github.com/rust-analyzer/rust-analyzer/releases/latest/download/rust-analyzer-windows.exe -o /PATH/TO/rust-analyzer.exe
+# x86_64 Windows
+$ curl -sL https://github.com/rust-analyzer/rust-analyzer/releases/latest/download/rust-analyzer-x86_64-pc-windows-msvc.gz | zcat >  /PATH/TO/rust-analyzer.exe
 ```
 
 


### PR DESCRIPTION
fix #197. 最近rust-analyzerがリリースバイナリのパスを変えたので追従します。
aarch64のバイナリも存在しますが、全部列挙すると長くなりそうなのでどうしましょうね。