### PR TITLE
Replace invitation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## Slack - <https://emacs-jp.slack.com>
 
-参加したい方は https://slack-emacs-jp.herokuapp.com/ からサインアップできます。
+参加したい方はこちらの [招待リンク](https://join.slack.com/t/emacs-jp/shared_invite/zt-1id7hvbxh-~n_wSBrdrHMk8~Ge8Fp3IQ) からサインアップできます。
 
 ## ページ作成者向け情報
 


### PR DESCRIPTION
close #210

Herokuの無料サービスが終了してしまうため, 招待リンクを slackが提供するものに切り替えます. unexpiredにしたので slackの方針が変更にならなければ変更することなく使えるものと思います.