### PR TITLE
Emacs JPサイトからのSlack招待リンクも差し替え

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,7 @@ Emacsと{{ site.title }}についての詳細は[このサイトについて](/a
 ## Slack <small>- [emacs-jp.slack.com](https://emacs-jp.slack.com/)</small>
 
 Emacs JPのSlack teamには多くのEmacsユーザーが常駐しています。  
-どなたでも <https://slack-emacs-jp.herokuapp.com/> からサインアップして参加できます。
+どなたでも <https://join.slack.com/t/emacs-jp/shared_invite/zt-1id7hvbxh-~n_wSBrdrHMk8~Ge8Fp3IQ> からサインアップして参加できます。
 
 Emacsについて、
 


### PR DESCRIPTION
fixes https://github.com/emacs-jp/emacs-jp.github.com/pull/211